### PR TITLE
fix: prevent username validators from accepting trailing newlines

### DIFF
--- a/django/contrib/auth/validators.py
+++ b/django/contrib/auth/validators.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 @deconstructible
 class ASCIIUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r'^[\w.@+-]+\Z'
     message = _(
         'Enter a valid username. This value may contain only English letters, '
         'numbers, and @/./+/-/_ characters.'
@@ -17,7 +17,7 @@ class ASCIIUsernameValidator(validators.RegexValidator):
 
 @deconstructible
 class UnicodeUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r'^[\w.@+-]+\Z'
     message = _(
         'Enter a valid username. This value may contain only letters, '
         'numbers, and @/./+/-/_ characters.'

--- a/test_username_validator_newline_bug.py
+++ b/test_username_validator_newline_bug.py
@@ -1,0 +1,35 @@
+import pytest
+from django.contrib.auth.validators import ASCIIUsernameValidator, UnicodeUsernameValidator
+from django.core.exceptions import ValidationError
+
+
+def test_issue_reproduction():
+    """Test that username validators reject usernames ending with newlines."""
+    ascii_validator = ASCIIUsernameValidator()
+    unicode_validator = UnicodeUsernameValidator()
+    
+    # Test usernames that should be valid (no newlines)
+    valid_usernames = ['testuser', 'test.user', 'test@example.com', 'test+user', 'test-user', 'test_user']
+    
+    for username in valid_usernames:
+        # These should not raise ValidationError
+        ascii_validator(username)
+        unicode_validator(username)
+    
+    # Test usernames with trailing newlines - these should be REJECTED but currently pass
+    invalid_usernames_with_newlines = [
+        'testuser\n',
+        'test.user\n', 
+        'test@example.com\n',
+        'test+user\n',
+        'test-user\n',
+        'test_user\n'
+    ]
+    
+    for username in invalid_usernames_with_newlines:
+        # These should raise ValidationError but currently don't due to the $ regex issue
+        with pytest.raises(ValidationError):
+            ascii_validator(username)
+        
+        with pytest.raises(ValidationError):
+            unicode_validator(username)


### PR DESCRIPTION
## Summary

Fixed a security issue where `ASCIIUsernameValidator` and `UnicodeUsernameValidator` incorrectly accepted usernames ending with newline characters due to Python's regex `$` anchor matching both end-of-string and end-of-string-before-newline.

## Changes

- Updated regex patterns in both validators from `r'^[\w.@+-]+$'` to `r'^[\w.@+-]+\Z'`
- The `\Z` anchor only matches true end-of-string, preventing usernames with trailing newlines from being accepted
- This ensures usernames are validated according to their intended specification

## Testing

All existing tests pass, including:
- `test_ascii_validator` - verifies ASCIIUsernameValidator properly rejects invalid usernames
- `test_unicode_validator` - verifies UnicodeUsernameValidator properly rejects invalid usernames  
- `test_help_text` - ensures help text generation works correctly

The fix ensures that usernames ending with newline characters (like `"user\n"`) are now properly rejected while maintaining acceptance of all valid usernames.

Closes #768

---
Closes #768