### PR TITLE
fix: preserve GROUP BY clause when filtering on query results

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -262,9 +262,11 @@ class Exact(FieldGetDbPrepValueMixin, BuiltinLookup):
         from django.db.models.sql.query import Query
         if isinstance(self.rhs, Query):
             if self.rhs.has_limit_one():
-                # The subquery must select only the pk.
-                self.rhs.clear_select_clause()
-                self.rhs.add_fields(['pk'])
+                # Only clear select clause and add pk field if the query doesn't already have select fields
+                if not getattr(self.rhs, 'has_select_fields', True):
+                    # The subquery must select only the pk.
+                    self.rhs.clear_select_clause()
+                    self.rhs.add_fields(['pk'])
             else:
                 raise ValueError(
                     'The QuerySet value for an exact lookup must be limited to '

--- a/tests/test_exact_lookup_group_by_bug.py
+++ b/tests/test_exact_lookup_group_by_bug.py
@@ -1,0 +1,35 @@
+import pytest
+from django.contrib.auth.models import User
+from django.db.models import Max
+from django.test import TestCase
+from django.db import connection
+
+
+def test_issue_reproduction():
+    """
+    Test that filtering on query result preserves GROUP BY of internal query.
+    
+    The bug: Exact.process_rhs unconditionally calls clear_select_clause() and 
+    add_fields(['pk']) on subqueries, which overrides the original GROUP BY clause.
+    """
+    # Create the subquery with custom select fields and GROUP BY
+    subquery = User.objects.filter(email__isnull=True).values('email').annotate(m=Max('id')).values('m')
+    
+    # Verify the subquery has the correct GROUP BY initially
+    subquery_sql = str(subquery.query)
+    assert 'GROUP BY "auth_user"."email"' in subquery_sql
+    
+    # Apply slicing to make it a single result (required for Exact lookup)
+    sliced_subquery = subquery[:1]
+    sliced_sql = str(sliced_subquery.query)
+    assert 'GROUP BY "auth_user"."email"' in sliced_sql
+    
+    # Now use this subquery in an Exact lookup (filter)
+    # This is where the bug occurs - the GROUP BY should be preserved
+    outer_query = User.objects.filter(id=sliced_subquery)
+    outer_sql = str(outer_query.query)
+    
+    # The bug: GROUP BY gets changed from U0."email" to U0."id"
+    # We expect it to remain GROUP BY U0."email" but it becomes GROUP BY U0."id"
+    assert 'GROUP BY U0."email"' in outer_sql, f"Expected GROUP BY U0.\"email\" but got: {outer_sql}"
+    assert 'GROUP BY U0."id"' not in outer_sql, f"Should not have GROUP BY U0.\"id\" but got: {outer_sql}"


### PR DESCRIPTION
## Summary

Fixes an issue where filtering on query results would override the GROUP BY clause of the internal query. The problem occurred in the `Exact.process_rhs` method which unconditionally cleared select fields and added only the primary key field, causing the GROUP BY clause to be rebuilt incorrectly.

## Changes

- Modified `Exact.process_rhs` method in `django/db/models/lookups.py` to check if the right-hand side query already has select fields before clearing them
- Added conditional logic similar to `In.process_rhs` to preserve existing select fields when they exist
- This ensures that queries with custom `values()` and `annotate()` calls maintain their original GROUP BY clauses

## Testing

The fix was verified by reproducing the original issue:
1. Created a query with `values().annotate()` that generates a specific GROUP BY clause
2. Used this query in a filter operation
3. Confirmed that the GROUP BY clause is now preserved correctly in the generated SQL
4. All existing tests continue to pass

Closes #784

---
Closes #784