### PR TITLE
fix: Allow sublanguages when base language is available in LANGUAGES setting

### DIFF
--- a/django/core/checks/translation.py
+++ b/django/core/checks/translation.py
@@ -57,5 +57,9 @@ def check_language_settings_consistent(app_configs, **kwargs):
     """Error if language settings are not consistent with each other."""
     available_tags = {i for i, _ in settings.LANGUAGES} | {'en-us'}
     if settings.LANGUAGE_CODE not in available_tags:
-        return [E004]
+        # Check if the base language is available for sublanguages
+        # e.g., 'de' for 'de-at'
+        base_language = settings.LANGUAGE_CODE.split('-')[0]
+        if base_language not in available_tags:
+            return [E004]
     return []

--- a/tests/check_framework/test_translation_sublanguage_bug.py
+++ b/tests/check_framework/test_translation_sublanguage_bug.py
@@ -1,0 +1,52 @@
+import pytest
+from django.conf import settings
+from django.core.checks.translation import check_language_settings_consistent, E004
+from django.test import override_settings
+
+
+def test_issue_reproduction():
+    """Test that translation.E004 is not raised when base language is available for sublanguage."""
+    
+    # Test case 1: de-at sublanguage with de base language available
+    # This should NOT raise E004 according to Django docs
+    with override_settings(
+        LANGUAGE_CODE='de-at',
+        LANGUAGES=[('de', 'German'), ('en', 'English')]
+    ):
+        errors = check_language_settings_consistent(None)
+        # This assertion will FAIL on buggy code because it incorrectly raises E004
+        assert errors == [], f"Expected no errors for de-at with de available, but got: {errors}"
+    
+    # Test case 2: es-ar sublanguage that exists in LANGUAGES (should work)
+    with override_settings(
+        LANGUAGE_CODE='es-ar', 
+        LANGUAGES=[('es-ar', 'Argentinian Spanish'), ('en', 'English')]
+    ):
+        errors = check_language_settings_consistent(None)
+        assert errors == [], f"Expected no errors for exact match es-ar, but got: {errors}"
+    
+    # Test case 3: fr-ca sublanguage with fr base language available
+    with override_settings(
+        LANGUAGE_CODE='fr-ca',
+        LANGUAGES=[('fr', 'French'), ('en', 'English')]
+    ):
+        errors = check_language_settings_consistent(None)
+        # This assertion will FAIL on buggy code
+        assert errors == [], f"Expected no errors for fr-ca with fr available, but got: {errors}"
+    
+    # Test case 4: Invalid sublanguage with no base language (should raise E004)
+    with override_settings(
+        LANGUAGE_CODE='xx-yy',
+        LANGUAGES=[('de', 'German'), ('en', 'English')]
+    ):
+        errors = check_language_settings_consistent(None)
+        assert len(errors) == 1
+        assert errors[0] == E004
+    
+    # Test case 5: Exact language match (should work)
+    with override_settings(
+        LANGUAGE_CODE='de',
+        LANGUAGES=[('de', 'German'), ('en', 'English')]
+    ):
+        errors = check_language_settings_consistent(None)
+        assert errors == []


### PR DESCRIPTION
## Summary

Fixes translation.E004 check to properly handle sublanguages when their base language is available in the LANGUAGES setting. Previously, Django would incorrectly raise an error for sublanguages like 'de-at' even when the base language 'de' was available, despite Django's documented behavior of falling back to the base language in such cases.

## Changes

- Modified `check_language_settings_consistent` function in `django/core/checks/translation.py`
- Added logic to extract base language code from sublanguages (e.g., 'de' from 'de-at')
- Check if base language exists in available languages when exact sublanguage match is not found
- This aligns the system check behavior with Django's actual runtime language resolution

## Testing

- All existing tests pass
- Verified that `LANGUAGE_CODE = 'de-at'` with `LANGUAGES` containing `'de'` no longer raises translation.E004
- Confirmed that the fix maintains backward compatibility for existing valid configurations
- Test case `test_valid_variant_consistent_language_settings` now passes as expected

Closes #800

---
Closes #800