### PR TITLE
fix: reject usernames with trailing newlines in username validators

### DIFF
--- a/django/contrib/auth/validators.py
+++ b/django/contrib/auth/validators.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 @deconstructible
 class ASCIIUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r'^[\w.@+-]+\Z'
     message = _(
         'Enter a valid username. This value may contain only English letters, '
         'numbers, and @/./+/-/_ characters.'
@@ -17,7 +17,7 @@ class ASCIIUsernameValidator(validators.RegexValidator):
 
 @deconstructible
 class UnicodeUsernameValidator(validators.RegexValidator):
-    regex = r'^[\w.@+-]+$'
+    regex = r'^[\w.@+-]+\Z'
     message = _(
         'Enter a valid username. This value may contain only letters, '
         'numbers, and @/./+/-/_ characters.'

--- a/tests/auth_tests/test_username_newline_bug.py
+++ b/tests/auth_tests/test_username_newline_bug.py
@@ -1,0 +1,44 @@
+import pytest
+from django.contrib.auth.validators import ASCIIUsernameValidator, UnicodeUsernameValidator
+from django.core.exceptions import ValidationError
+
+
+def test_issue_reproduction():
+    """Test that username validators reject usernames with trailing newlines."""
+    ascii_validator = ASCIIUsernameValidator()
+    unicode_validator = UnicodeUsernameValidator()
+    
+    # Test usernames with trailing newlines that should be rejected
+    invalid_usernames = [
+        'validuser\n',  # single trailing newline
+        'test@example.com\n',  # email-like username with newline
+        'user.name\n',  # username with dot and newline
+        'user+tag\n',  # username with plus and newline
+        'user-name\n',  # username with dash and newline
+        'user_name\n',  # username with underscore and newline
+    ]
+    
+    # Test that ASCIIUsernameValidator rejects usernames with trailing newlines
+    for username in invalid_usernames:
+        with pytest.raises(ValidationError, match=r'Enter a valid username'):
+            ascii_validator(username)
+    
+    # Test that UnicodeUsernameValidator rejects usernames with trailing newlines
+    for username in invalid_usernames:
+        with pytest.raises(ValidationError, match=r'Enter a valid username'):
+            unicode_validator(username)
+    
+    # Verify that valid usernames (without newlines) are still accepted
+    valid_usernames = [
+        'validuser',
+        'test@example.com',
+        'user.name',
+        'user+tag',
+        'user-name',
+        'user_name',
+    ]
+    
+    # These should not raise any exceptions
+    for username in valid_usernames:
+        ascii_validator(username)  # Should pass without exception
+        unicode_validator(username)  # Should pass without exception


### PR DESCRIPTION
## Summary

Fixes username validators to properly reject usernames containing trailing newlines by replacing `$` with `\Z` in regex patterns.

Closes #841

## Changes

- Updated `ASCIIUsernameValidator` regex pattern from `r'^[\w.@+-]+$'` to `r'^[\w.@+-]+\Z'`
- Updated `UnicodeUsernameValidator` regex pattern from `r'^[\w.@+-]+$'` to `r'^[\w.@+-]+\Z'`

The issue was that Python's `$` anchor matches both the end of string and before a trailing newline character. By using `\Z` instead, the validators now only match at the absolute end of the string, properly rejecting usernames that end with newline characters while maintaining compatibility with valid usernames.

## Testing

All existing tests pass, including the specific test cases that were failing:
- `test_ascii_validator` - verifies ASCIIUsernameValidator rejects usernames with trailing newlines
- `test_unicode_validator` - verifies UnicodeUsernameValidator rejects usernames with trailing newlines  
- `test_help_text` - ensures help text generation still works correctly

The fix ensures usernames like `"valid_user\n"` are now properly rejected while `"valid_user"` continues to be accepted.

---
Closes #841