### PR TITLE
feat: Add validation check for CharField max_length vs choices

### DIFF
--- a/django/db/models/fields/__init__.py
+++ b/django/db/models/fields/__init__.py
@@ -955,6 +955,7 @@ class CharField(Field):
         return [
             *super().check(**kwargs),
             *self._check_max_length_attribute(**kwargs),
+            *self._check_choices_max_length(),
         ]
 
     def _check_max_length_attribute(self, **kwargs):
@@ -977,6 +978,56 @@ class CharField(Field):
             ]
         else:
             return []
+
+    def _check_choices_max_length(self):
+        if not self.choices or self.max_length is None:
+            return []
+
+        errors = []
+        
+        def check_choice_value(value):
+            if isinstance(value, str) and len(value) > self.max_length:
+                return checks.Error(
+                    "'max_length' is too small to fit the longest value "
+                    "in 'choices' (%d characters)." % len(value),
+                    obj=self,
+                    id='fields.E009',
+                )
+            return None
+
+        for choice in self.choices:
+            try:
+                # Check if this is a named group: (group_name, [(value, label), ...])
+                group_name, group_choices = choice
+                if isinstance(group_choices, (list, tuple)):
+                    # This is a named group
+                    for group_choice in group_choices:
+                        try:
+                            value, label = group_choice
+                            error = check_choice_value(value)
+                            if error:
+                                errors.append(error)
+                        except (TypeError, ValueError):
+                            # Invalid choice format, but that's handled by _check_choices
+                            pass
+                else:
+                    # This might be a simple choice: (value, label)
+                    value, label = choice
+                    error = check_choice_value(value)
+                    if error:
+                        errors.append(error)
+            except (TypeError, ValueError):
+                # This might be a simple choice: (value, label)
+                try:
+                    value, label = choice
+                    error = check_choice_value(value)
+                    if error:
+                        errors.append(error)
+                except (TypeError, ValueError):
+                    # Invalid choice format, but that's handled by _check_choices
+                    pass
+
+        return errors
 
     def cast_db_type(self, connection):
         if self.max_length is None:

--- a/tests/test_charfield_max_length_choices.py
+++ b/tests/test_charfield_max_length_choices.py
@@ -1,0 +1,77 @@
+import pytest
+from django.core.checks import Error
+from django.db import models
+from django.test import TestCase
+
+
+def test_issue_reproduction():
+    """Test that CharField validates max_length against choice values."""
+    
+    # Test case 1: Simple choices where max_length is too small
+    class TestModel1(models.Model):
+        field = models.CharField(
+            max_length=2,
+            choices=[
+                ('short', 'Short'),
+                ('very_long_choice', 'Very Long Choice'),  # This is 17 chars, exceeds max_length=2
+            ]
+        )
+        
+        class Meta:
+            app_label = 'test'
+    
+    # Test case 2: Named groups with choices where max_length is too small
+    class TestModel2(models.Model):
+        field = models.CharField(
+            max_length=5,
+            choices=[
+                ('Group 1', [
+                    ('short', 'Short'),
+                    ('medium', 'Medium'),
+                ]),
+                ('Group 2', [
+                    ('extremely_long_choice_value', 'Extremely Long'),  # This is 29 chars, exceeds max_length=5
+                    ('ok', 'OK'),
+                ]),
+            ]
+        )
+        
+        class Meta:
+            app_label = 'test'
+    
+    # Test case 3: Valid case - max_length is sufficient
+    class TestModel3(models.Model):
+        field = models.CharField(
+            max_length=20,
+            choices=[
+                ('short', 'Short'),
+                ('medium_length', 'Medium Length'),  # This is 13 chars, fits in max_length=20
+            ]
+        )
+        
+        class Meta:
+            app_label = 'test'
+    
+    # Check the fields - these should fail for models 1 and 2, pass for model 3
+    field1 = TestModel1._meta.get_field('field')
+    field2 = TestModel2._meta.get_field('field')
+    field3 = TestModel3._meta.get_field('field')
+    
+    errors1 = field1.check()
+    errors2 = field2.check()
+    errors3 = field3.check()
+    
+    # The current implementation should NOT catch these errors (test should fail)
+    # After the fix, these assertions should pass:
+    
+    # Model 1 should have an error about 'very_long_choice' being too long
+    choice_length_errors1 = [e for e in errors1 if 'max_length' in str(e.msg) and 'choice' in str(e.msg)]
+    assert len(choice_length_errors1) > 0, "Expected validation error for choice value exceeding max_length in simple choices"
+    
+    # Model 2 should have an error about 'extremely_long_choice_value' being too long  
+    choice_length_errors2 = [e for e in errors2 if 'max_length' in str(e.msg) and 'choice' in str(e.msg)]
+    assert len(choice_length_errors2) > 0, "Expected validation error for choice value exceeding max_length in named groups"
+    
+    # Model 3 should have no such errors
+    choice_length_errors3 = [e for e in errors3 if 'max_length' in str(e.msg) and 'choice' in str(e.msg)]
+    assert len(choice_length_errors3) == 0, "Expected no validation errors when all choices fit within max_length"


### PR DESCRIPTION
## Summary

Adds a validation check to ensure that `CharField.max_length` is large enough to accommodate the longest value in `Field.choices`. This prevents runtime errors when attempting to save records with choice values that exceed the field's maximum length.

## Changes

- Added `_check_choices_max_length()` method to `CharField` class in `django/db/models/fields/__init__.py`
- Enhanced the `check()` method in `CharField` to include the new validation
- The validation handles both simple choices and nested choices within named groups
- Returns descriptive error messages when choice values exceed `max_length`

The implementation iterates through all choice values (flattening named groups) and compares their lengths against the field's `max_length` parameter. If any choice value is longer than `max_length`, a validation error is raised with details about the problematic choice.

## Testing

Verified that the following previously failing tests now pass:
- `test_choices_in_max_length (invalid_models_tests.test_ordinary_fields.CharFieldTests)`
- `test_choices_named_group (invalid_models_tests.test_ordinary_fields.CharFieldTests)`

The validation correctly identifies when choice values exceed the specified `max_length` and provides clear error messages to help developers identify and fix the issue during development rather than at runtime.

Closes #856

---
Closes #856