### PR TITLE
fix: preserve GROUP BY clause when filtering on query results

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -263,8 +263,9 @@ class Exact(FieldGetDbPrepValueMixin, BuiltinLookup):
         if isinstance(self.rhs, Query):
             if self.rhs.has_limit_one():
                 # The subquery must select only the pk.
-                self.rhs.clear_select_clause()
-                self.rhs.add_fields(['pk'])
+                if not getattr(self.rhs, 'has_select_fields', True):
+                    self.rhs.clear_select_clause()
+                    self.rhs.add_fields(['pk'])
             else:
                 raise ValueError(
                     'The QuerySet value for an exact lookup must be limited to '

--- a/tests/test_exact_lookup_group_by_bug.py
+++ b/tests/test_exact_lookup_group_by_bug.py
@@ -1,0 +1,31 @@
+import pytest
+from django.contrib.auth.models import User
+from django.db.models import Max
+from django.test import TestCase
+from django.db import connection
+
+
+def test_issue_reproduction():
+    """
+    Test that filtering on query result preserves GROUP BY of internal query.
+    
+    This test reproduces the bug where Exact.process_rhs overrides the GROUP BY
+    clause when using a subquery with values() and annotate().
+    """
+    # Create the subquery that should group by 'email'
+    subquery = User.objects.filter(email__isnull=True).values('email').annotate(m=Max('id')).values('m')[:1]
+    
+    # Use the subquery in an exact lookup
+    main_query = User.objects.filter(id=subquery)
+    
+    # Get the SQL to inspect the GROUP BY clause
+    sql = str(main_query.query)
+    
+    # The subquery should GROUP BY email, not id
+    # The bug causes it to GROUP BY U0."id" instead of U0."email"
+    assert 'GROUP BY U0."email"' in sql, f"Expected GROUP BY U0.\"email\" but got: {sql}"
+    assert 'GROUP BY U0."id"' not in sql, f"Found incorrect GROUP BY U0.\"id\" in: {sql}"
+    
+    # Additional verification: the subquery alone should have correct GROUP BY
+    subquery_sql = str(subquery.query)
+    assert 'GROUP BY "auth_user"."email"' in subquery_sql, f"Subquery should group by email: {subquery_sql}"


### PR DESCRIPTION
## Summary

Fixes an issue where filtering on query results with GROUP BY clauses would override the original GROUP BY field with the primary key field in the generated subquery.

## Changes

Modified the `Exact.process_rhs` method in `django/db/models/lookups.py` to check if the subquery already has select fields before clearing the select clause and adding the primary key field. This follows the same pattern used in the `In.process_rhs` method and preserves the original GROUP BY clause when it exists.

The fix ensures that when filtering on annotated query results, the subquery maintains its intended GROUP BY behavior rather than being overridden with `GROUP BY pk`.

## Testing

Added a comprehensive test case that reproduces the original issue by:
1. Creating a query with `.values()`, `.annotate()`, and `.values()` that generates a GROUP BY clause
2. Using this query as a filter in another query
3. Verifying that the generated SQL preserves the original GROUP BY field instead of replacing it with the primary key

All existing tests continue to pass, confirming that the change doesn't break existing functionality.

Closes #858

---
Closes #858