### PR TITLE
fix: Prevent using __isnull lookup with non-boolean values

### DIFF
--- a/django/db/models/lookups.py
+++ b/django/db/models/lookups.py
@@ -462,6 +462,13 @@ class IsNull(BuiltinLookup):
     lookup_name = 'isnull'
     prepare_rhs = False
 
+    def get_prep_lookup(self):
+        if not isinstance(self.rhs, bool):
+            raise ValueError(
+                "The __isnull lookup expects a boolean value, got %r." % self.rhs
+            )
+        return self.rhs
+
     def as_sql(self, compiler, connection):
         sql, params = compiler.compile(self.lhs)
         if self.rhs:

--- a/tests/test_isnull_validation.py
+++ b/tests/test_isnull_validation.py
@@ -1,0 +1,45 @@
+import pytest
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.test import TestCase
+from django.db.models.lookups import IsNull
+
+
+class TestModel(models.Model):
+    name = models.CharField(max_length=100, null=True)
+    
+    class Meta:
+        app_label = 'test'
+
+
+def test_issue_reproduction():
+    """Test that __isnull lookup should only accept boolean values."""
+    
+    # These should work (boolean values)
+    try:
+        # Test with True
+        lookup_true = IsNull(TestModel._meta.get_field('name'), True)
+        assert lookup_true.rhs is True
+        
+        # Test with False  
+        lookup_false = IsNull(TestModel._meta.get_field('name'), False)
+        assert lookup_false.rhs is False
+    except Exception as e:
+        pytest.fail(f"Boolean values should be accepted: {e}")
+    
+    # These should raise errors (non-boolean values)
+    non_boolean_values = [
+        'true',      # string 'true'
+        'false',     # string 'false' 
+        1,           # integer 1 (truthy)
+        0,           # integer 0 (falsy)
+        'yes',       # string 'yes' (truthy)
+        '',          # empty string (falsy)
+        [],          # empty list (falsy)
+        [1],         # non-empty list (truthy)
+        None,        # None (falsy)
+    ]
+    
+    for value in non_boolean_values:
+        with pytest.raises((ValueError, TypeError), match=r".*isnull.*boolean.*"):
+            IsNull(TestModel._meta.get_field('name'), value)


### PR DESCRIPTION
## Summary

Adds validation to the `IsNull` lookup to ensure only boolean values are accepted, preventing confusion and maintaining consistency with documented behavior. This change raises a `ValueError` when non-boolean values are passed to the `__isnull` lookup.

## Changes

- Modified the `IsNull` lookup class in `django/db/models/lookups.py` to validate that the right-hand side (rhs) value is a boolean
- Added validation that raises a `ValueError` with a descriptive message when non-boolean values are provided
- Maintains backward compatibility for existing code using proper boolean values (`True`/`False`)

## Testing

- All existing tests continue to pass, ensuring no regression in functionality
- The validation correctly accepts boolean `True` and `False` values
- Non-boolean values (strings, integers, None, etc.) now properly raise `ValueError` with clear error messages
- Existing `__isnull` functionality remains intact for valid boolean inputs

Closes #864

---
Closes #864