### PR TITLE
fix: Allow sublanguages in LANGUAGE_CODE when base language is available

### DIFF
--- a/django/core/checks/translation.py
+++ b/django/core/checks/translation.py
@@ -57,5 +57,12 @@ def check_language_settings_consistent(app_configs, **kwargs):
     """Error if language settings are not consistent with each other."""
     available_tags = {i for i, _ in settings.LANGUAGES} | {'en-us'}
     if settings.LANGUAGE_CODE not in available_tags:
+        # Check if base language is available for sublanguages
+        # e.g., 'de-at' should be valid if 'de' is in available_tags
+        language_code = settings.LANGUAGE_CODE
+        if '-' in language_code:
+            base_language = language_code.split('-')[0]
+            if base_language in available_tags:
+                return []
         return [E004]
     return []

--- a/tests/check_framework/test_translation_sublanguage_bug.py
+++ b/tests/check_framework/test_translation_sublanguage_bug.py
@@ -1,0 +1,52 @@
+import pytest
+from django.conf import settings
+from django.core.checks import Error
+from django.core.checks.translation import check_language_settings_consistent, E004
+from django.test import override_settings
+
+
+def test_issue_reproduction():
+    """Test that translation.E004 is not raised when base language is available for sublanguage."""
+    
+    # Test case 1: sublanguage 'de-at' with base language 'de' available
+    # This should NOT raise E004 error according to Django docs
+    with override_settings(
+        LANGUAGE_CODE='de-at',
+        LANGUAGES=[('de', 'German'), ('en', 'English')]
+    ):
+        errors = check_language_settings_consistent(None)
+        # This assertion will FAIL on current buggy code because it raises E004
+        # but should PASS after fix since 'de' base language is available
+        assert errors == [], f"Expected no errors for sublanguage with available base language, got: {errors}"
+    
+    # Test case 2: sublanguage 'es-mx' with base language 'es' available
+    with override_settings(
+        LANGUAGE_CODE='es-mx', 
+        LANGUAGES=[('es', 'Spanish'), ('en', 'English')]
+    ):
+        errors = check_language_settings_consistent(None)
+        assert errors == [], f"Expected no errors for sublanguage with available base language, got: {errors}"
+    
+    # Test case 3: sublanguage without base language should still raise E004
+    with override_settings(
+        LANGUAGE_CODE='fr-ca',
+        LANGUAGES=[('de', 'German'), ('en', 'English')]  # no 'fr' base language
+    ):
+        errors = check_language_settings_consistent(None)
+        assert errors == [E004], f"Expected E004 error for sublanguage without base language, got: {errors}"
+    
+    # Test case 4: exact match should work (no error)
+    with override_settings(
+        LANGUAGE_CODE='de-at',
+        LANGUAGES=[('de-at', 'Austrian German'), ('en', 'English')]
+    ):
+        errors = check_language_settings_consistent(None)
+        assert errors == [], f"Expected no errors for exact language match, got: {errors}"
+    
+    # Test case 5: base language exact match should work
+    with override_settings(
+        LANGUAGE_CODE='de',
+        LANGUAGES=[('de', 'German'), ('en', 'English')]
+    ):
+        errors = check_language_settings_consistent(None)
+        assert errors == [], f"Expected no errors for base language match, got: {errors}"


### PR DESCRIPTION
## Summary

Fixes translation.E004 check to properly handle sublanguages when a base language is available in the LANGUAGES setting. This aligns the system check behavior with Django's documented fallback mechanism for language codes.

## Changes

- Modified `check_language_settings_consistent` function in `django/core/checks/translation.py` to check for base language availability when a sublanguage is specified in `LANGUAGE_CODE`
- Added logic to extract base language code (e.g., 'de' from 'de-at') and verify it exists in LANGUAGES setting
- Maintains existing behavior for direct language matches and adds proper sublanguage support

## Testing

The fix was validated using the existing test `test_valid_variant_consistent_language_settings` which verifies that:
- `LANGUAGE_CODE = 'de-at'` is accepted when `'de'` is available in LANGUAGES
- `LANGUAGE_CODE = 'es-ar'` continues to work as before
- The translation.E004 error is no longer raised inappropriately for valid sublanguage configurations

Closes #878

---
Closes #878