### PR TITLE
fix: raise NotSupportedError when distinct() is called on union querysets

### DIFF
--- a/django/db/models/query.py
+++ b/django/db/models/query.py
@@ -1138,6 +1138,11 @@ class QuerySet:
         """
         Return a new QuerySet instance that will select only distinct results.
         """
+        if self.query.combinator:
+            raise NotSupportedError(
+                'Calling distinct() after %s() is not supported.'
+                % self.query.combinator
+            )
         assert not self.query.is_sliced, \
             "Cannot create distinct fields once a slice has been taken."
         obj = self._chain()

--- a/tests/queries/test_union_distinct.py
+++ b/tests/queries/test_union_distinct.py
@@ -1,0 +1,55 @@
+import pytest
+from django.db import NotSupportedError
+from django.db import models
+from django.db.models import Value, IntegerField
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+
+class Sample(models.Model):
+    name = models.CharField(max_length=100)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    
+    class Meta:
+        app_label = 'test_app'
+
+
+def test_issue_reproduction():
+    """Test that distinct() on union queryset should raise NotSupportedError."""
+    # Create test user
+    user = User.objects.create_user('testuser', 'test@example.com', 'password')
+    
+    # Create test data
+    Sample.objects.create(user=user, name="Sam1")
+    Sample.objects.create(user=user, name="Sam2 acid")
+    Sample.objects.create(user=user, name="Sam3")
+    Sample.objects.create(user=user, name="Sam4 acid")
+    Sample.objects.create(user=user, name="Dub")
+    Sample.objects.create(user=user, name="Dub")
+    Sample.objects.create(user=user, name="Dub")
+    
+    # Create querysets with annotations
+    qs = Sample.objects.filter(user=user)
+    qs1 = qs.filter(name='Dub').annotate(rank=Value(0, IntegerField()))
+    qs2 = qs.filter(name='Sam1').annotate(rank=Value(1, IntegerField()))
+    
+    # Create union queryset
+    union_qs = qs1.union(qs2)
+    
+    # This should raise NotSupportedError but currently doesn't
+    with pytest.raises(NotSupportedError, match=r"Calling distinct\(\) after union\(\) is not supported"):
+        union_qs.distinct()
+    
+    # Also test distinct with field names
+    with pytest.raises(NotSupportedError, match=r"Calling distinct\(\) after union\(\) is not supported"):
+        union_qs.distinct('name')
+    
+    # Test with intersection as well
+    intersection_qs = qs1.intersection(qs2)
+    with pytest.raises(NotSupportedError, match=r"Calling distinct\(\) after intersection\(\) is not supported"):
+        intersection_qs.distinct()
+    
+    # Test with difference as well
+    difference_qs = qs1.difference(qs2)
+    with pytest.raises(NotSupportedError, match=r"Calling distinct\(\) after difference\(\) is not supported"):
+        difference_qs.distinct()


### PR DESCRIPTION
## Summary

This PR fixes an issue where calling `distinct()` on union querysets would silently fail to apply the distinct operation instead of raising an appropriate error. The fix adds validation to raise `NotSupportedError` when `distinct()` is called on combined querysets (union/intersection/difference), following the same pattern as other unsupported operations.

## Changes

- Modified the `distinct()` method in `QuerySet` class to check if the queryset is a result of union/intersection/difference operations
- Added a check that raises `NotSupportedError` with an appropriate error message when `distinct()` is called on combined querysets
- This brings consistency with other QuerySet methods that already raise `NotSupportedError` for combined querysets

## Testing

- Verified that the existing test `test_unsupported_operations_on_comb` now passes
- Confirmed that calling `distinct()` on union querysets now properly raises `NotSupportedError` instead of silently failing
- No new test failures were introduced by this change

Closes #896

---
Closes #896