### PR TITLE
fix: strip leading and trailing dashes/underscores in slugify()

### DIFF
--- a/django/utils/text.py
+++ b/django/utils/text.py
@@ -395,7 +395,8 @@ def slugify(value, allow_unicode=False):
     """
     Convert to ASCII if 'allow_unicode' is False. Convert spaces to hyphens.
     Remove characters that aren't alphanumerics, underscores, or hyphens.
-    Convert to lowercase. Also strip leading and trailing whitespace.
+    Convert to lowercase. Also strip leading and trailing whitespace, dashes,
+    and underscores.
     """
     value = str(value)
     if allow_unicode:
@@ -403,7 +404,7 @@ def slugify(value, allow_unicode=False):
     else:
         value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore').decode('ascii')
     value = re.sub(r'[^\w\s-]', '', value.lower()).strip()
-    return re.sub(r'[-\s]+', '-', value)
+    return re.sub(r'[-\s]+', '-', value).strip('-_')
 
 
 def camel_case_to_spaces(value):

--- a/tests/utils_tests/test_text_slugify_strip.py
+++ b/tests/utils_tests/test_text_slugify_strip.py
@@ -1,0 +1,29 @@
+import pytest
+from django.utils.text import slugify
+
+def test_issue_reproduction():
+    """Test that slugify strips leading and trailing dashes and underscores."""
+    # Test the exact example from the issue
+    result = slugify("___This is a test ---")
+    expected = "this-is-a-test"
+    assert result == expected, f"Expected '{expected}', got '{result}'"
+    
+    # Test additional edge cases with leading/trailing dashes and underscores
+    assert slugify("---hello world___") == "hello-world"
+    assert slugify("_-_test_-_") == "test"
+    assert slugify("___") == ""
+    assert slugify("---") == ""
+    assert slugify("_-_-_") == ""
+    assert slugify("__hello__") == "hello"
+    assert slugify("--world--") == "world"
+    
+    # Test mixed leading/trailing characters
+    assert slugify("_-hello world-_") == "hello-world"
+    assert slugify("--__test__--") == "test"
+    
+    # Test that internal dashes/underscores are preserved
+    assert slugify("hello_world-test") == "hello_world-test"
+    
+    # Test normal cases still work
+    assert slugify("Hello World") == "hello-world"
+    assert slugify("test") == "test"


### PR DESCRIPTION
## Summary

Modified `django.utils.text.slugify()` to strip leading and trailing dashes and underscores from the output. This fixes the issue where inputs like `'___This is a test ---'` would produce `'___this-is-a-test-'` instead of the expected `'this-is-a-test'`.

## Changes

- Updated the `slugify()` function in `django/utils/text.py` to add a `.strip('-_')` operation on the final result
- This ensures that any leading or trailing dashes and underscores are removed from the generated slug
- The change is minimal and focused, only affecting the final output formatting without altering the core slugification logic

## Testing

- Verified that the existing `test_slugify` test in `utils_tests.test_text.TestUtilsText` now passes
- Confirmed that `slugify('___This is a test ---')` now returns `'this-is-a-test'` instead of `'___this-is-a-test-'`
- No new test failures were introduced by this change

Closes #900

---
Closes #900